### PR TITLE
Clean branch before cherry-picking

### DIFF
--- a/src/cli/test/__snapshots__/cliService.test.js.snap
+++ b/src/cli/test/__snapshots__/cliService.test.js.snap
@@ -30,7 +30,7 @@ Object {
 exports[`doBackportVersion with commit reference 2`] = `
 Array [
   Array [
-    "git reset --hard && git checkout master && git pull origin master",
+    "git reset --hard && git clean -d --force && git checkout master && git pull origin master",
     Object {
       "cwd": "/homefolder/.backport/repositories/elastic/kibana",
     },
@@ -86,7 +86,7 @@ Object {
 exports[`doBackportVersion with pull request reference 2`] = `
 Array [
   Array [
-    "git reset --hard && git checkout master && git pull origin master",
+    "git reset --hard && git clean -d --force && git checkout master && git pull origin master",
     Object {
       "cwd": "/homefolder/.backport/repositories/elastic/kibana",
     },

--- a/src/cli/test/__snapshots__/steps.test.js.snap
+++ b/src/cli/test/__snapshots__/steps.test.js.snap
@@ -15,7 +15,7 @@ Array [
     },
   ],
   Array [
-    "git reset --hard && git checkout master && git pull origin master",
+    "git reset --hard && git clean -d --force && git checkout master && git pull origin master",
     Object {
       "cwd": "/homefolder/.backport/repositories/elastic/backport-cli-test",
     },

--- a/src/lib/git.js
+++ b/src/lib/git.js
@@ -69,7 +69,7 @@ function push(owner, repoName, username, branchName) {
 
 function resetAndPullMaster(owner, repoName) {
   return rpc.exec(
-    `git reset --hard && git checkout master && git pull origin master`,
+    `git reset --hard && git clean -d --force && git checkout master && git pull origin master`,
     {
       cwd: env.getRepoPath(owner, repoName)
     }


### PR DESCRIPTION
Untracked files won't be removed with `git reset --hard`. In some edge cases, there will be untracked files, which must be removed, before a checkout to master can occur.

This PR ensures that untracked files are removed before cherry-picking occurs.